### PR TITLE
🌈 Improve checking out remote branch

### DIFF
--- a/src/git/branch.ts
+++ b/src/git/branch.ts
@@ -2,7 +2,7 @@ import execa from 'execa';
 import { EOL } from 'os';
 import { ensureRepository } from './repository';
 
-const FORMAT_SEPARATOR = '##__##';
+export const FORMAT_SEPARATOR = '##__##';
 
 /**
  * Get a list of local branches and their remote tracking branches.


### PR DESCRIPTION
Previously we used the ref to find a path, but this doesn't work if the branch is already checkout locally and has unpushed commits, since the ref is different.

We now use `branch -vv` and iterate over the list of branches to find the branch.